### PR TITLE
feat: `LOOP` statements

### DIFF
--- a/compiler/CompileEnvIntf.java
+++ b/compiler/CompileEnvIntf.java
@@ -31,4 +31,11 @@ public interface CompileEnvIntf {
 	 *  get function table
 	 */
 	public FunctionTable getFunctionTable();
+
+	void pushLoopStack(InstrBlock instrBlock);
+
+	InstrBlock peekLoopStack();
+
+	InstrBlock popLoopStack();
+
 }

--- a/compiler/Lexer.java
+++ b/compiler/Lexer.java
@@ -77,6 +77,7 @@ public class Lexer implements LexerIntf, LexerParserIntf {
         addKeywordMachine("DO", compiler.TokenIntf.Type.DO);
         addKeywordMachine("FOR", compiler.TokenIntf.Type.FOR);
         addKeywordMachine("LOOP", compiler.TokenIntf.Type.LOOP);
+        addKeywordMachine("ENDLOOP", TokenIntf.Type.ENDLOOP);
         addKeywordMachine("BREAK", compiler.TokenIntf.Type.BREAK);
         addKeywordMachine("SWITCH", compiler.TokenIntf.Type.SWITCH);
         addKeywordMachine("CASE", compiler.TokenIntf.Type.CASE);

--- a/compiler/Parser.java
+++ b/compiler/Parser.java
@@ -235,7 +235,13 @@ public class Parser {
 			return getWhileStatement();
             //   stmt: functionCallStmt // SELECT = {DOWHILE}
 		} else if (m_lexer.lookAhead().m_type == Token.Type.DO) {
-			return getDoWhileStatement();
+            return getDoWhileStatement();
+        //   stmt: loopStmt // SELECT = {LOOP}
+        } else if (this.m_lexer.lookAhead().m_type == Type.LOOP) {
+            return this.getLoopStatement();
+        //   stmt: breakStmt // SELECT = {BREAK}
+        } else if (this.m_lexer.lookAhead().m_type == Type.BREAK) {
+            return this.getBreakStatement();
         }else {
             m_lexer.throwCompilerException("Unexpected Statement", "");
         }
@@ -400,4 +406,19 @@ public class Parser {
         m_lexer.expect(TokenIntf.Type.SEMICOLON);
         return new ASTDoWhileStmtNode(exprNode, blockstmt);
     }
+
+    private ASTStmtNode getLoopStatement() throws Exception {
+        // loopStmt: LOOP blockStmt ENDLOOP
+        m_lexer.expect(Type.LOOP);
+        final ASTStmtNode block = getBlockStmt();
+        m_lexer.expect(Type.ENDLOOP);
+        return new ASTLoopStmtNode(block);
+    }
+
+    private ASTStmtNode getBreakStatement() throws Exception {
+        // breakStmt: BREAK
+        this.m_lexer.expect(Type.BREAK);
+        return ASTBreakStmtNode.BREAK_STATEMENT_NODE;
+    }
+
 }

--- a/compiler/Parser.java
+++ b/compiler/Parser.java
@@ -420,7 +420,7 @@ public class Parser {
     private ASTStmtNode getBreakStatement() throws Exception {
         // breakStmt: BREAK
         this.m_lexer.expect(Type.BREAK);
-        return ASTBreakStmtNode.BREAK_STATEMENT_NODE;
+        return ASTBreakStmtNode.STATEMENT_NODE;
     }
 
     ASTStmtNode getExecuteNTimesStatement() throws Exception {

--- a/compiler/TokenIntf.java
+++ b/compiler/TokenIntf.java
@@ -42,6 +42,7 @@ public abstract class TokenIntf {
 		DO,
 		FOR,
 		LOOP,
+		ENDLOOP,
 		BREAK,
 		SWITCH,
 		CASE,

--- a/compiler/ast/ASTBlockStmtNode.java
+++ b/compiler/ast/ASTBlockStmtNode.java
@@ -18,8 +18,7 @@ public class ASTBlockStmtNode extends ASTStmtNode {
 
     @Override
     public void execute() {
-        // TODO Auto-generated method stub
-        
+        this.m_stmtList.execute();
     }
 
     @Override

--- a/compiler/ast/ASTBreakStmtNode.java
+++ b/compiler/ast/ASTBreakStmtNode.java
@@ -1,0 +1,23 @@
+package compiler.ast;
+
+import java.io.OutputStreamWriter;
+
+public class ASTBreakStmtNode extends ASTStmtNode {
+
+    public static ASTBreakStmtNode BREAK_STATEMENT_NODE = new ASTBreakStmtNode();
+
+    public static class BreakException extends RuntimeException {
+
+    }
+
+    @Override
+    public void print(OutputStreamWriter outStream, String indent) throws Exception {
+        outStream.write(indent + "BREAK\n");
+    }
+
+    @Override
+    public void execute() {
+        throw new BreakException();
+    }
+
+}

--- a/compiler/ast/ASTBreakStmtNode.java
+++ b/compiler/ast/ASTBreakStmtNode.java
@@ -1,23 +1,35 @@
 package compiler.ast;
 
+import compiler.CompileEnvIntf;
+import compiler.InstrBlock;
+import compiler.InstrIntf;
+import compiler.instr.InstrJump;
+
 import java.io.OutputStreamWriter;
 
 public class ASTBreakStmtNode extends ASTStmtNode {
 
-    public static ASTBreakStmtNode BREAK_STATEMENT_NODE = new ASTBreakStmtNode();
+    public static final ASTBreakStmtNode STATEMENT_NODE = new ASTBreakStmtNode();
 
     public static class BreakException extends RuntimeException {
 
     }
 
     @Override
-    public void print(OutputStreamWriter outStream, String indent) throws Exception {
-        outStream.write(indent + "BREAK\n");
+    public void print(final OutputStreamWriter out, final String indent) throws Exception {
+        out.write(indent + "BREAK\n");
     }
 
     @Override
     public void execute() {
         throw new BreakException();
+    }
+
+    @Override
+    public InstrIntf codegen(final CompileEnvIntf env) {
+        final InstrBlock loopExit = env.peekLoopStack();
+        env.addInstr(new InstrJump(loopExit));
+        return null;
     }
 
 }

--- a/compiler/ast/ASTLoopStmtNode.java
+++ b/compiler/ast/ASTLoopStmtNode.java
@@ -1,8 +1,6 @@
 package compiler.ast;
 
-import compiler.CompileEnvIntf;
-import compiler.InstrBlock;
-import compiler.InstrIntf;
+import compiler.*;
 import compiler.instr.InstrJump;
 
 import java.io.OutputStreamWriter;
@@ -37,9 +35,13 @@ public class ASTLoopStmtNode extends ASTStmtNode {
         final InstrBlock loopBody = env.createBlock("loop_body");
         final InstrBlock loopExit = env.createBlock("loop_exit");
 
+        env.pushLoopStack(loopExit);
+
         env.addInstr(new InstrJump(loopBody));
         env.setCurrentBlock(loopBody);
         this.block.codegen(env);
+
+        env.popLoopStack();
 
         env.addInstr(new InstrJump(loopExit));
         env.setCurrentBlock(loopExit);

--- a/compiler/ast/ASTLoopStmtNode.java
+++ b/compiler/ast/ASTLoopStmtNode.java
@@ -1,0 +1,54 @@
+package compiler.ast;
+
+import compiler.CompileEnvIntf;
+import compiler.InstrBlock;
+import compiler.InstrIntf;
+import compiler.instr.InstrJump;
+
+import java.io.OutputStreamWriter;
+
+public class ASTLoopStmtNode extends ASTStmtNode {
+    private final ASTStmtNode block;
+
+    public ASTLoopStmtNode(final ASTStmtNode block) {
+        this.block = block;
+    }
+
+    @Override
+    public void print(final OutputStreamWriter out, final String indent) throws Exception {
+        out.write(indent + "LOOP {\n");
+        this.block.print(out, indent + "  ");
+        out.write(indent + "}\n");
+    }
+
+    @Override
+    public void execute() {
+        while (true) {
+            try {
+                this.block.execute();
+            } catch (final ASTBreakStmtNode.BreakException ignored) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public InstrIntf codegen(final CompileEnvIntf env) {
+        final InstrBlock loopBody = env.createBlock("loop_body");
+        final InstrBlock loopExit = env.createBlock("loop_exit");
+
+        env.addInstr(new InstrJump(loopBody));
+        env.setCurrentBlock(loopBody);
+        this.block.codegen(env);
+
+        env.addInstr(new InstrJump(loopExit));
+        env.setCurrentBlock(loopExit);
+        return null;
+    }
+
+    @Override
+    public boolean semicolAfter() {
+        return false;
+    }
+
+}


### PR DESCRIPTION
In Beispielprogramm 3 waren noch ein paar Fehler, wir haben mit folgendem Programm getestet:

```
DECLARE index;
DECLARE innerIndex;
DECLARE sum;
index = 0;
sum = 0;
LOOP {
    index = index + 1;
    innerIndex = 0;
    LOOP {
        innerIndex = innerIndex + 1;
        IF (innerIndex == 10) {
            BREAK;
        }
        sum = sum + innerIndex;
    } ENDLOOP
    IF (index == 10) {
        BREAK;
    }
} ENDLOOP
PRINT index;
PRINT innerIndex;
PRINT sum;
```